### PR TITLE
feat: centralize depth_minus helper in utilities

### DIFF
--- a/Collatz/Foundations/TwoAdicDepth.lean
+++ b/Collatz/Foundations/TwoAdicDepth.lean
@@ -7,21 +7,18 @@ This file contains definitions and properties related to 2-adic depth:
 - Properties of depth_minus
 -/
 import Mathlib.Data.Nat.Factorization.Basic
+import Collatz.Utilities.TwoAdicDepth
 import Collatz.Foundations.Arithmetic
 
 namespace Collatz
 
-/-- Depth to -1 (2-adic depth): depth_-(r) = ν_2(r+1) -/
-def depth_minus (r : ℕ) : ℕ := (r + 1).factorization 2
-
 /-- Basic property: depth_minus is non-negative -/
 lemma depth_minus_nonneg (r : ℕ) : depth_minus r ≥ 0 := by
-  unfold depth_minus
   exact Nat.zero_le _
 
-/-- depth_minus of 0 is 1 -/
-lemma depth_minus_zero : depth_minus 0 = 1 := by
-  sorry -- TODO: Complete proof
+/-- depth_minus of 0 is 0 -/
+lemma depth_minus_zero : depth_minus 0 = 0 := by
+  simp [depth_minus]
 
 /-- depth_minus of odd numbers is at least 1 -/
 lemma depth_minus_odd_pos {r : ℕ} (h : Odd r) : depth_minus r ≥ 1 := by

--- a/Collatz/SEDT/Core.lean
+++ b/Collatz/SEDT/Core.lean
@@ -9,6 +9,7 @@ import Init.Data.Nat.Div.Basic
 import Collatz.Foundations.Basic
 import Collatz.Epochs.Structure
 import Collatz.Utilities.Constants
+import Collatz.Utilities.TwoAdicDepth
 
 /-!
 # SEDT (Shumak Epoch Drift Theorem)
@@ -35,13 +36,6 @@ open Collatz.Utilities (α β₀ ε C L₀ K_glue V Q_t Q_t_pos)
 /-!
 ## Potential Function and Constants
 -/
-
-/-- Depth-minus function: ν₂(r+1) for odd r -/
-def depth_minus (r : ℕ) : ℕ :=
-  (r + 1).factorization 2
-
--- Note: Constants α, β₀, ε, C, L₀, K_glue, V are now imported from Collatz.Utilities.Constants
--- This eliminates duplication and ensures consistency across the project.
 
 /-!
 ## Helper Lemmas for Constants
@@ -415,21 +409,7 @@ lemma log_part_le_one (r : ℕ) (hr : r > 0) (_hr_odd : Odd r) :
 lemma single_step_potential_bounded (r : ℕ) (β : ℝ) (hr : r > 0) (hr_odd : Odd r) (hβ : β ≥ 1) :
   single_step_ΔV r β ≤ log (3/2) / log 2 + β * 2 := by
   unfold single_step_ΔV
-  -- Use local V definition since imported V has sorry for depth_minus
-  have V_local : V (T_shortcut r) β - V r β =
-    (log (T_shortcut r) / log 2 + β * (depth_minus (T_shortcut r) : ℝ)) -
-    (log r / log 2 + β * (depth_minus r : ℝ)) := by
-    unfold V
-    simp [depth_minus]
-    ring_nf
-    simp
-    -- Need to show: β * (depth_minus (T_shortcut r) : ℝ) - β * (depth_minus r : ℝ) = 0
-    -- This follows from depth_drop_one_shortcut: depth_minus (T_shortcut r) + 1 = depth_minus r
-    -- So: depth_minus (T_shortcut r) = depth_minus r - 1
-    -- Therefore: β * (depth_minus (T_shortcut r) : ℝ) - β * (depth_minus r : ℝ) = β * ((depth_minus r - 1) : ℝ) - β * (depth_minus r : ℝ) = β * (depth_minus r : ℝ) - β - β * (depth_minus r : ℝ) = -β
-    -- But we need 0, so this suggests the imported V definition is wrong
-    sorry -- TODO: Fix this
-  rw [V_local]
+  simp [V]
 
   -- Step 1: Use depth_drop_one_shortcut
   have h_depth : depth_minus (T_shortcut r) + 1 = depth_minus r :=

--- a/Collatz/Utilities.lean
+++ b/Collatz/Utilities.lean
@@ -3,16 +3,19 @@ Collatz Conjecture: Epoch-Based Deterministic Framework
 Utilities Aggregator
 
 This module aggregates all utility modules:
+- Two-adic depth helpers
 - Constants registry (Appendix D)
 - Unified notation conventions
 - Examples and demonstrations
 -/
+import Collatz.Utilities.TwoAdicDepth
 import Collatz.Utilities.Constants
 import Collatz.Utilities.Notation
 import Collatz.Utilities.Examples
 
 -- This module aggregates all utility modules
 -- All definitions are available through their respective modules:
+-- - Collatz.Utilities.TwoAdicDepth
 -- - Collatz.Utilities.Constants
 -- - Collatz.Utilities.Notation
 -- - Collatz.Utilities.Examples

--- a/Collatz/Utilities/Constants.lean
+++ b/Collatz/Utilities/Constants.lean
@@ -11,8 +11,11 @@ import Mathlib.Data.Real.Basic
 import Mathlib.Data.Nat.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Collatz.Utilities.TwoAdicDepth
 
 namespace Collatz.Utilities
+
+open Collatz
 
 -- Core Epoch Constants
 
@@ -68,7 +71,8 @@ def c_b : ℝ := sorry -- TODO: Define based on phase analysis
 -- Potential Function (Appendix D, line 70)
 
 -- Augmented potential V(n) = log₂ n + β · depth_-(n)
-noncomputable def V (n : ℕ) (β : ℝ) : ℝ := Real.log (n : ℝ) / Real.log 2 + β * sorry -- TODO: depth_minus n
+noncomputable def V (n : ℕ) (β : ℝ) : ℝ :=
+  Real.log (n : ℝ) / Real.log 2 + β * (depth_minus n : ℝ)
 
 -- Change in potential across epoch
 def ΔV : ℝ := sorry -- TODO: Define based on epoch analysis

--- a/Collatz/Utilities/TwoAdicDepth.lean
+++ b/Collatz/Utilities/TwoAdicDepth.lean
@@ -1,0 +1,23 @@
+/-!
+## Two-adic depth utilities
+
+This module exposes the `depth_minus` helper used across the Collatz
+formalization.  The definition lives in the shared utilities namespace so
+that both the SEDT machinery and other components (e.g. constants,
+foundational lemmas) can import a single canonical version.
+-/
+import Mathlib.Data.Nat.Factorization.Basic
+
+namespace Collatz
+
+/-- Two-adic depth towards `-1`: `depth_minus r = ν₂(r + 1)`.
+
+This measures the multiplicity of the prime `2` in the number `r + 1`, and
+is the key valuation used when tracking parity transitions in the reduced
+Collatz dynamics.
+-/
+def depth_minus (r : ℕ) : ℕ := (r + 1).factorization 2
+
+@[simp] lemma depth_minus_add_one (r : ℕ) : depth_minus r = (r + 1).factorization 2 := rfl
+
+end Collatz


### PR DESCRIPTION
## Summary
- add a shared Collatz.Utilities.TwoAdicDepth module that defines `depth_minus`
- reuse the shared helper in the constants registry and SEDT core, fixing `V`
- clean up foundational lemmas to reference the new definition

## Testing
- `lake build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e13a376960832e9cb2559f9d05beb3